### PR TITLE
Added anMessage severity for older Confluence

### DIFF
--- a/src/messages/an-message.directive.js
+++ b/src/messages/an-message.directive.js
@@ -7,7 +7,7 @@
 
             // jscs:disable
             var defaultTemplate = [
-                '<div ng-style="message.styleContainer" class="aui-message aui-message-{{ message.severity }}">',
+                '<div ng-style="message.styleContainer" class="aui-message aui-message-{{ message.severity }} {{ message.severity }}">',
                 '   <p ng-if="message.title" class="title">',
                 '       <span class="aui-icon icon-{{ message.severity }}"></span>',
                 '       <strong ng-bind="message.title"></strong>',


### PR DESCRIPTION
In older Confluence versions, the class attribute for messages must be like "aui-message [severity]" with severity like error, info, etc.
Now the class attribute is like "aui-message aui-message-[severity] [severity]" so that it supports all options.
