### PR TITLE
IVSN-4886: update AUI message styling to work with AUI 8

### DIFF
--- a/src/messages/an-message.directive.js
+++ b/src/messages/an-message.directive.js
@@ -9,7 +9,6 @@
             var defaultTemplate = [
                 '<div ng-style="message.styleContainer" class="aui-message aui-message-{{ message.severity }} {{ message.severity }}">',
                 '   <p ng-if="message.title" class="title">',
-                '       <span class="aui-icon icon-{{ message.severity }}"></span>',
                 '       <strong ng-bind="message.title"></strong>',
                 '   </p>',
                 '   <div ng-style="message.styleMessageWrapper">',


### PR DESCRIPTION
Explicitly adding the severity level icon is not required since at least
AUI 5.10 and starting from AUI 8 breaks the layout

In older AUI versions (5.10 - 7) the extra icon is just hidden by adding extra css setting display: none, but in AUI 8 they have got rid of this deprecated mode support CSS